### PR TITLE
fix: fix /about route - add missing import and correct response text

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import PlainTextResponse
 from contextlib import asynccontextmanager
 from pydantic import BaseModel
 from typing import Optional
@@ -78,9 +79,9 @@ def create_task(task: TaskCreate):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/about",response_class=PlainTextResponse)
+@app.get("/about", response_class=PlainTextResponse)
 def about_backend():
-    return "This is all backend"
+    return "This is all about backend"
 
 @app.get("/tasks")
 def list_tasks(limit: int = 100):


### PR DESCRIPTION
## Summary
- Added missing `from fastapi.responses import PlainTextResponse` import
- The existing `/about` route used `PlainTextResponse` as `response_class` but it was never imported, causing a `NameError` at runtime
- Fixed response text from "This is all backend" to "This is all about backend" per the acceptance criteria in #31

Closes #31

## Test plan
- [x] `GET /about` returns plain text `"This is all about backend"`
- [x] No authentication required
- [x] Response is in plain text (via `PlainTextResponse`)

